### PR TITLE
v1.2.0: Convert to all ES5 syntax for IE11 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
     install(Vue, options) {
         Vue.$geocoder = Vue.prototype.$geocoder = {
             defaultCountryCode: options.defaultCountryCode || null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pderas/vue2-geocoder",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A vue 2 plugin to interact with google maps api",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## About this PR
- Closes #5 

This PR makes the code so it is valid ES5 syntax so it will be supported with IE11.

## Before
Most of the module was already ES5 syntax, but the export was not.

## After
We now completely ES5 folks

## QA
- [ ] Copy the contents of [index.js](https://raw.githubusercontent.com/PDERAS/vue2-geocoder/8d935c137f3f6b408ef8a1ef7829138f0502f9b1/index.js) into the [syntax checker](https://esprima.org/demo/validate.html) and it should pass

## References
[ES5 vs ES6](https://engineering.carsguide.com.au/es5-vs-es6-syntax-6c8350fa6998)